### PR TITLE
feat: Add pair info to getLockedLiquidity

### DIFF
--- a/src/constants/contracts.ts
+++ b/src/constants/contracts.ts
@@ -2,7 +2,11 @@ export enum Entrypoint {
   LOCKED_LIQUIDITY = 'locked_liquidity',
   LIQUIDITY_POSITION_DETAILS = 'liquidity_position_details',
   GET_TOKEN_INFOS = 'get_token_info',
+  TOTAL_SUPPLY = 'total_supply',
+  DECIMALS = 'decimals',
+  AGGREGATE = 'aggregate',
 }
 
 export const UNRUG_FACTORY_ADDRESS = '0x01a46467a9246f45c8c340f1f155266a26a71c07bd55d36e8d1c7d0d438a2dbc'
 export const EKUBO_POSITIONS = '0x02e0af29598b407c8716b17f6d2795eca1b471413fa03fb145a5e33722184067'
+export const MULTICALL_ADDRESS = '0x01a33330996310a1e3fa1df5b16c1e07f0491fdd20c441126e02613b948f0225'

--- a/src/utils/contract.ts
+++ b/src/utils/contract.ts
@@ -1,0 +1,34 @@
+import { Call, CallData, hash, ProviderInterface } from 'starknet'
+import {  Entrypoint, MULTICALL_ADDRESS } from '@/constants/contracts'
+
+
+export async function multiCallContract(
+  provider: ProviderInterface,
+  calls: Call[],
+) {
+  const calldata = calls.map((call) => {
+    return CallData.compile({
+      to: call.contractAddress,
+      selector: hash.getSelector(call.entrypoint),
+      calldata: call.calldata ?? [],
+    })
+  })
+
+  const rawResult = await provider.callContract({
+    contractAddress: MULTICALL_ADDRESS,
+    entrypoint: Entrypoint.AGGREGATE,
+    calldata: [calldata.length, ...calldata.flat()],
+  })
+  const raw = rawResult.slice(2)
+
+  const result: string[][] = []
+  let idx = 0
+
+  for (let i = 0; i < raw.length; i += idx + 1) {
+    idx = parseInt(raw[i], 16)
+
+    result.push(raw.slice(i + 1, i + 1 + idx))
+  }
+
+  return result
+}


### PR DESCRIPTION
Reorganized the output JSON of `/get_locked_liquidity` endpoint to match the requested format.

- quoteTokenAddress: Address of the quote token
- totalSupply: Total supply of the memecoin
- liquidity: Ekubo liquidity
- lockedAmount: Locked token0 amount on the ekubo position
- lockedPercentage: Percentage of the token0 amount to the total supply
- lockedPair: Memecoin and quote token pair

Example output:

```json
{
    "quoteTokenAddress": "0x04718f5a0Fc34cC1AF16A1cdee98fFB20C31f5cD61D6Ab07201858f4287c938D",
    "totalSupply": "1000000000000000000000000000000000",
    "liquidity": "4806246186022693327763080264",
    "lockedAmount": "93652950372463994938794284993002",
    "lockedPercentage": 9.3652950372464,
    "lockedPair": [
        {
            "amount": "93652950372463994938794284993002",
            "decimals": 18,
            "tokenAddress": "0x03B405a98C9E795D427Fe82CDEeeed803F221B52471E3a757574a2b4180793EE"
        },
        {
            "amount": "222339570257383332792850",
            "decimals": 18,
            "tokenAddress": "0x04718f5a0Fc34cC1AF16A1cdee98fFB20C31f5cD61D6Ab07201858f4287c938D"
        }
    ]
}
```